### PR TITLE
Silence clang warning

### DIFF
--- a/src/te.c
+++ b/src/te.c
@@ -127,7 +127,7 @@ static const char* lasterror( void )
 static int err( unsigned errno )
 {
 	terrno = errno;
-	puts((verrmsg)?lasterror():(":3?"+2*(errno!=8)));
+	puts((verrmsg)?lasterror():(&":3?"[2*(errno!=8)]));
 	return 1;
 }
 


### PR DESCRIPTION
Changed implicit char pointer arithmetic to array index notation to stop clang from complaining.